### PR TITLE
Fix for blocked git protocol

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "dependencies": {
-    "rocambole": "git://github.com/millermedeiros/rocambole.git#1bd5044df1d6c888a1bd1b511158fb34b011e9aa",
+    "rocambole": "git+https://github.com/millermedeiros/rocambole.git#1bd5044df1d6c888a1bd1b511158fb34b011e9aa",
     "lodash": "~2.4.1",
     "rocambole-token": "~1.2.1",
     "underscore.string": "~2.4.0"


### PR DESCRIPTION
Some corporate networks block the git protocol.  This addition will allow atom-react to be installed on those networks.  See  emissary for example.  https://github.com/atom/emissary/blob/master/package.json
